### PR TITLE
Save multiple results in cache

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -10,7 +10,7 @@
 	font-family:Arial;
 	font-size: 12px;
 	font-weight:bold;
-	padding:11px 23px;
+	margin:5px;
 	text-decoration:none;
 	text-shadow:0px -1px 0px #2b665e;
 }

--- a/popup.html
+++ b/popup.html
@@ -12,6 +12,7 @@
    </head>
    <body>
      <button class="copyButton" id="changeColor">Copy Result</button>
+     <button class="copyButton" id="sendToClip"> Save Results</button>
      <script src="popup.js"></script>
    </body>
  </html>

--- a/popup.js
+++ b/popup.js
@@ -1,13 +1,12 @@
-let changeColor = document.getElementById('changeColor');
+let saveResult = document.getElementById("changeColor");
 
 chrome.storage.sync.get('color', function(data) {
-  changeColor.style.backgroundColor = data.color;
-  changeColor.setAttribute('value', data.color);
+  saveResult.style.backgroundColor = data.color;
+  saveResult.setAttribute('value', data.color);
 });
 
-changeColor.onclick = function(element) {
-    var csvResult
-    let color = element.target.value;
+saveResult.addEventListener("click",function() {
+    // let color = element.target.value;
 
     // TODO :: Can we separate these queries?
 
@@ -40,18 +39,24 @@ changeColor.onclick = function(element) {
                 runAt: 'document_start', // default is document_idle. See https://stackoverflow.com/q/42509273 for more details.
                 }, function(results) {
                   // results.length must be 1
-                  result += results[0];
-                    navigator.clipboard.writeText(result + "\n").then(() => {
-                        //clipboard successfully set
-                      }, () => {
-                        //clipboard write failed, use fallback
-                      });
+                  result += results[0] + "\n";
+                  let storedResults = window.localStorage.getItem("results");
+                  if (storedResults === null) {
+                    storedResults = "";
+                  }
+                  window.localStorage.setItem("results", window.localStorage.getItem("results") + result);
                   });
             });
         });
     });
-  };
+  });
 
+let sendToClip = document.getElementById("sendToClip");
+sendToClip.addEventListener("click", function(){
+  let results = (window.localStorage.getItem("results"));
+  window.localStorage.setItem("results", "");
+  navigator.clipboard.writeText(results + "\n").then(() => {}, () => {});
+});
 // Look into searching by element class name after getting the div 'primary'
 const furigana =
 `                  // array of spans, each containing either a section of the furigana or nothing (in case of a okurigana in the original word)

--- a/popup.js
+++ b/popup.js
@@ -17,9 +17,11 @@ saveResult.addEventListener("click",function() {
         runAt: 'document_start', // default is document_idle. See https://stackoverflow.com/q/42509273 for more details.
         }, function(results) {
           // results.length must be 1
-          var result = results[0].trim();
+        let result = results[0].trim();
+        // Key for dictionary
+        let key = result;
 
-          chrome.tabs.executeScript(null, {
+        chrome.tabs.executeScript(null, {
             // TODO :: What should happen here if no furigana are available? What about if there are okurigana?
             code: furigana,
             allFrames: false, // this is the default
@@ -40,11 +42,12 @@ saveResult.addEventListener("click",function() {
                 }, function(results) {
                   // results.length must be 1
                   result += results[0] + "\n";
-                  let storedResults = window.localStorage.getItem("results");
+                  let storedResults = JSON.parse(window.localStorage.getItem("results"));
                   if (storedResults === null) {
-                    storedResults = "";
+                    storedResults = {};
                   }
-                  window.localStorage.setItem("results", window.localStorage.getItem("results") + result);
+                  storedResults[key] = result;
+                  window.localStorage.setItem("results", JSON.stringify(storedResults));
                   });
             });
         });
@@ -53,9 +56,17 @@ saveResult.addEventListener("click",function() {
 
 let sendToClip = document.getElementById("sendToClip");
 sendToClip.addEventListener("click", function(){
-  let results = (window.localStorage.getItem("results"));
-  window.localStorage.setItem("results", "");
-  navigator.clipboard.writeText(results + "\n").then(() => {}, () => {});
+  let results = JSON.parse(window.localStorage.getItem("results"));
+  let resultString = "";
+  for (const key in results){
+    // skip prototype keys
+    if (!results.hasOwnProperty(key)) continue;
+    resultString += results[key];
+  }
+
+  // clearing saved buffer
+  window.localStorage.setItem("results", JSON.stringify({}));
+  navigator.clipboard.writeText(resultString).then(() => {}, () => {});
 });
 // Look into searching by element class name after getting the div 'primary'
 const furigana =


### PR DESCRIPTION
Changed workflow from search word -> press button -> paste to personal sheet, 

to

search word -> press button -> repeat until all words saved -> press other button -> paste all at once 


This uses the browser's `localStorage` capability, which stores information for each page between browser closes. 
If we want to, we can change it to `sessionStorage`, which only saves information until the browser is closed. This would prevent accidentally adding definitions from past sessions, but also if you close the browser accidentally all unsaved definitions would be lost. 



